### PR TITLE
Try to add an integration test. Error

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,10 +21,8 @@ dependencies {
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 
-    // This dependency is exported to consumers, that is to say found on their compile classpath.
-    api 'org.apache.commons:commons-math3:3.6.1'
-
-    implementation 'io.grpc:grpc-okhttp:1.35.0'
+    // without this dependency grpc call from Hedera SDK throws an error
+    implementation 'io.grpc:grpc-okhttp:1.45.1'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
@@ -32,6 +30,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
     implementation 'com.github.multiformats:java-multibase:1.1.0'
     implementation group: 'org.javatuples', name: 'javatuples', version: '1.2'
+    implementation 'org.awaitility:awaitility:4.2.0'
 }
 
 tasks.named('test') {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
 
+    implementation 'io.grpc:grpc-okhttp:1.35.0'
+
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation 'com.hedera.hashgraph:sdk-jdk7:2.10.1'

--- a/lib/src/main/java/com/hedera/hashgraph/identity/DidMethodOperation.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/DidMethodOperation.java
@@ -1,5 +1,7 @@
 package com.hedera.hashgraph.identity;
 
+import java.util.Arrays;
+
 public enum DidMethodOperation {
 
     CREATE("create"),
@@ -12,6 +14,12 @@ public enum DidMethodOperation {
     DidMethodOperation(String label) {
 
         this.label = label;
+    }
+
+    public static DidMethodOperation get(final String typeName) {
+        return Arrays.stream(values())
+                .filter(t -> t.label.equals(typeName)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid DID service type name: " + typeName));
     }
 
     @Override

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDid.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDid.java
@@ -132,6 +132,10 @@ public class HcsDid {
         return Hashing.Multibase.encode(publicKey.toBytes());
     }
 
+    public static PublicKey stringToPublicKey(String idString) {
+        return PublicKey.fromBytes(Hashing.Multibase.decode(idString));
+    }
+
     public DidDocument resolve() throws DidError {
         if (this.identifier == null) {
             throw new DidError("DID is not registered");

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDid.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDid.java
@@ -222,9 +222,6 @@ public class HcsDid {
 
     }
 
-    public String getIdentifier() {
-        return this.identifier;
-    }
 
     private MessageEnvelope<HcsDidMessage> submitTransaction(DidMethodOperation didMethodOperation, HcsDidEvent event, PrivateKey privateKey) throws DidError, JsonProcessingException {
         HcsDidMessage message = new HcsDidMessage(didMethodOperation, this.identifier, event);
@@ -243,4 +240,35 @@ public class HcsDid {
 
         return messageRef.get();
     }
+
+    /**
+     * Attribute getters
+     */
+
+    public String getIdentifier() {
+        return this.identifier;
+    }
+
+    public Client getClient() {
+        return this.client;
+    }
+
+    public PrivateKey getPrivateKey() {
+        return this.privateKey;
+    }
+
+
+    public String getNetwork() {
+        return this.network;
+    }
+
+    public String getMethod() {
+        return HcsDid.DID_METHOD;
+    }
+
+    public HcsDidMessage[] getMessages() {
+        return this.messages;
+    }
+
+
 }

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidEventMessageResolver.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidEventMessageResolver.java
@@ -21,7 +21,7 @@ public class HcsDidEventMessageResolver {
     /**
      * Default time to wait before finishing resolution and after the last message was received.
      */
-    public static final long DEFAULT_TIMEOUT = 30_000;
+    public static final long DEFAULT_TIMEOUT = 3000000;
     private final AtomicLong lastMessageArrivalTime;
     private final HcsDidTopicListener listener;
     private final ScheduledExecutorService executorService;

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidEventMessageResolver.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidEventMessageResolver.java
@@ -21,7 +21,7 @@ public class HcsDidEventMessageResolver {
     /**
      * Default time to wait before finishing resolution and after the last message was received.
      */
-    public static final long DEFAULT_TIMEOUT = 3000000;
+    public static final long DEFAULT_TIMEOUT = 300_000;
     private final AtomicLong lastMessageArrivalTime;
     private final HcsDidTopicListener listener;
     private final ScheduledExecutorService executorService;

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidMessage.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidMessage.java
@@ -37,14 +37,14 @@ public class HcsDidMessage {
     }
 
     public static HcsDidMessage fromJsonTree(JsonNode tree, HcsDidMessage result) {
-        HcsDidEvent event = HcsDidEventParser.fromBase64(DidMethodOperation.valueOf(tree.get("operation").textValue()), tree.get("event").textValue());
+        HcsDidEvent event = HcsDidEventParser.fromBase64(DidMethodOperation.get(tree.get("operation").textValue()), tree.get("event").textValue());
 
         HcsDidMessage hcsDidMessage;
         if (result == null) {
-            hcsDidMessage = new HcsDidMessage(DidMethodOperation.valueOf(tree.get("operation").textValue()), tree.get("did").textValue(), event);
+            hcsDidMessage = new HcsDidMessage(DidMethodOperation.get(tree.get("operation").textValue()), tree.get("did").textValue(), event);
         } else {
             hcsDidMessage = result;
-            hcsDidMessage.operation = DidMethodOperation.valueOf(tree.get("operation").textValue());
+            hcsDidMessage.operation = DidMethodOperation.get(tree.get("operation").textValue());
             hcsDidMessage.did = tree.get("did").textValue();
             hcsDidMessage.event = event;
         }
@@ -109,7 +109,7 @@ public class HcsDidMessage {
     }
 
     public JsonNode toJsonTree() throws JsonProcessingException {
-        return new ObjectMapper().readTree("{\"timestamp\":" + this.getTimestamp().toString() + ",\"operation\":" + this.operation + ",\"did\":" + this.did + ", \"event\":" + this.getEventBase64() + "}");
+        return new ObjectMapper().readTree("{\"timestamp\":\"" + this.getTimestamp().toString() + "\",\"operation\":\"" + this.operation + "\",\"did\":\"" + this.did + "\", \"event\":\"" + this.getEventBase64() + "\"}");
 
     }
 

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTransaction.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTransaction.java
@@ -33,7 +33,7 @@ public class HcsDidTransaction {
      * @param topicId The HCS DID topic ID where message will be submitted.
      */
     HcsDidTransaction(MessageEnvelope<HcsDidMessage> message, TopicId topicId) throws DidError {
-        if (message instanceof MessageEnvelope && topicId instanceof TopicId) {
+        if (message != null && topicId != null) {
             this.topicId = topicId;
             this.message = message;
             this.executed = false;
@@ -49,7 +49,7 @@ public class HcsDidTransaction {
      * @return The topic listener for this message on a mirror node.
      */
     protected HcsDidTopicListener provideTopicListener(TopicId topicIdToListen) {
-        return new HcsDidTopicListener(topicIdToListen, null);
+        return new HcsDidTopicListener(topicIdToListen);
     }
 
     /**
@@ -138,7 +138,7 @@ public class HcsDidTransaction {
      * @return Transaction ID.
      */
     public TransactionId execute(final Client client) throws JsonProcessingException, DidError {
-        new Validator().checkValidationErrors("MessageTransaction execution failed: ", v -> validate(v));
+        new Validator().checkValidationErrors("MessageTransaction execution failed: ", this::validate);
 
         MessageEnvelope<HcsDidMessage> envelope = this.message;
         byte[] messageContent = envelope.getSignature() == null ? envelope.toJSON().getBytes(StandardCharsets.UTF_8) : envelope.sign(signer);

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidIntegrationTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.hedera.hashgraph.identity.hcs.did;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.hashgraph.identity.DidError;
+import com.hedera.hashgraph.sdk.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+@Disabled
+public class HcsDidIntegrationTest {
+
+    final AccountId operatorId = AccountId.fromString("0.0.12...");
+    final PrivateKey operatorKey = PrivateKey.fromString("302e02...");
+    final List<String> mirrorNetworks = List.of("hcs.testnet.mirrornode.hedera.com:5600");
+
+    final Client client = Client.forTestnet();
+
+    @Test
+    @DisplayName("register did")
+    void registerDID() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
+        HcsDid did = new HcsDid(null, this.operatorKey, this.client);
+
+        // register
+        String identifier = did.register().getIdentifier();
+        System.out.println(identifier);
+
+        ObjectMapper mapper = new ObjectMapper();
+        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(did.resolve().toJsonTree()));
+
+    }
+
+
+    @Test
+    @DisplayName("resolve did")
+    void resolveDID() throws JsonProcessingException, DidError {
+        String identifier = "did:hedera:testnet:z6Mkg6N8h78J9vBFPv8inrnwikWSph4un3SnofPzrPQzbTDX_0.0.34099687";
+        HcsDid registeredDid = new HcsDid(identifier, null, this.client);
+
+        //resolve did
+        ObjectMapper mapper = new ObjectMapper();
+        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(registeredDid.resolve().toJsonTree()));
+
+    }
+}

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -3,15 +3,14 @@ package com.hedera.hashgraph.identity.hcs.did;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hedera.hashgraph.identity.DidError;
 import com.hedera.hashgraph.sdk.*;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
+@Disabled
 public class HcsDidTest {
     final AccountId operatorId = AccountId.fromString("0.0.2xxx");
     final PrivateKey operatorKey = PrivateKey.fromString("302xxx");
@@ -25,13 +24,28 @@ public class HcsDidTest {
     }
 
     @Test
-    @DisplayName("throws error if DID is already registered")
-    void itTestsIfDIDIsAlreadyRegistered() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
-        PrivateKey privateKey = this.operatorKey;
-        HcsDid did = new HcsDid(null, privateKey, this.client);
+    @DisplayName("register did")
+    void registerDID() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
+        HcsDid did = new HcsDid(null, this.operatorKey, this.client);
 
-        did.register();
-        DidError error = assertThrows(DidError.class, did::register);
-        assertEquals("", error.getMessage());
+        // register
+        String identifier = did.register().getIdentifier();
+        System.out.println(identifier);
+
+        System.out.println(did.resolve().toJSON());
+
     }
+
+    //TODO: WIP
+
+//    @Test
+//    @DisplayName("resolve did")
+//    void resolveDID() throws JsonProcessingException, DidError {
+//        String identifier = "did:hedera:testnet:z6MkhHbhBBLdKGiGnHPvrrH9GL7rgw6egpZiLgvQ9n7pHt1P_0.0.34099347";
+//        HcsDid did = new HcsDid(identifier, null, this.client);
+//
+//        //resolve did
+//        System.out.println(did.resolve().toJSON());
+//
+//    }
 }

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -1,20 +1,18 @@
 package com.hedera.hashgraph.identity.hcs.did;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hashgraph.identity.DidError;
-import com.hedera.hashgraph.sdk.*;
-import org.junit.jupiter.api.Disabled;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
-@Disabled
 public class HcsDidTest {
-    final AccountId operatorId = AccountId.fromString("0.0.2xxx");
-    final PrivateKey operatorKey = PrivateKey.fromString("302xxx");
+    final AccountId operatorId = AccountId.fromString("0.0.12710106");
+    final PrivateKey operatorKey = PrivateKey.fromString("302e020100300506032b657004220420bc45334a1313725653d3513fcc67edb15f76985f537ca567e2177b0be9906d49");
     final List<String> mirrorNetworks = List.of("hcs.testnet.mirrornode.hedera.com:5600");
 
     final Client client = Client.forTestnet();
@@ -26,31 +24,23 @@ public class HcsDidTest {
 
 
     @Test
-    @DisplayName("register did")
-    void registerDID() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
-        HcsDid did = new HcsDid(null, this.operatorKey, this.client);
-
-        // register
-        String identifier = did.register().getIdentifier();
-        System.out.println(identifier);
-
-        ObjectMapper mapper = new ObjectMapper();
-        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(did.resolve().toJsonTree()));
-
+    @DisplayName("throws error because of missing identifier and privateKey")
+    void testErrorWhenMissingIdentifierAndPk() throws DidError {
+        Assertions.assertThrowsExactly(DidError.class, () -> new HcsDid(null, null, null), "identifier and privateKey cannot both be empty");
     }
-
 
     @Test
-    @DisplayName("resolve did")
-    void resolveDID() throws JsonProcessingException, DidError {
-        String identifier = "did:hedera:testnet:z6Mkg6N8h78J9vBFPv8inrnwikWSph4un3SnofPzrPQzbTDX_0.0.34099687";
-        HcsDid registeredDid = new HcsDid(identifier, null, this.client);
+    @DisplayName("successfully builds HcsDid with private key only")
+    void testBuildWithPk() throws DidError {
+        PrivateKey privateKey = PrivateKey.generateED25519();
+        HcsDid did = new HcsDid(null, privateKey, null);
 
-        //resolve did
-        ObjectMapper mapper = new ObjectMapper();
-        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(registeredDid.resolve().toJsonTree()));
+        Assertions.assertNull(did.getIdentifier());
+        Assertions.assertEquals(privateKey, did.getPrivateKey());
+        Assertions.assertNull(did.getClient());
+        Assertions.assertNull(did.getTopicId());
+        Assertions.assertNull(did.getNetwork());
 
     }
-
 
 }

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -1,6 +1,7 @@
 package com.hedera.hashgraph.identity.hcs.did;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hashgraph.identity.DidError;
 import com.hedera.hashgraph.sdk.*;
 import org.junit.jupiter.api.Disabled;
@@ -23,6 +24,7 @@ public class HcsDidTest {
         this.client.setOperator(this.operatorId, this.operatorKey);
     }
 
+
     @Test
     @DisplayName("register did")
     void registerDID() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
@@ -32,20 +34,23 @@ public class HcsDidTest {
         String identifier = did.register().getIdentifier();
         System.out.println(identifier);
 
-        System.out.println(did.resolve().toJSON());
+        ObjectMapper mapper = new ObjectMapper();
+        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(did.resolve().toJsonTree()));
 
     }
 
-    //TODO: WIP
 
-//    @Test
-//    @DisplayName("resolve did")
-//    void resolveDID() throws JsonProcessingException, DidError {
-//        String identifier = "did:hedera:testnet:z6MkhHbhBBLdKGiGnHPvrrH9GL7rgw6egpZiLgvQ9n7pHt1P_0.0.34099347";
-//        HcsDid did = new HcsDid(identifier, null, this.client);
-//
-//        //resolve did
-//        System.out.println(did.resolve().toJSON());
-//
-//    }
+    @Test
+    @DisplayName("resolve did")
+    void resolveDID() throws JsonProcessingException, DidError {
+        String identifier = "did:hedera:testnet:z6Mkg6N8h78J9vBFPv8inrnwikWSph4un3SnofPzrPQzbTDX_0.0.34099687";
+        HcsDid registeredDid = new HcsDid(identifier, null, this.client);
+
+        //resolve did
+        ObjectMapper mapper = new ObjectMapper();
+        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(registeredDid.resolve().toJsonTree()));
+
+    }
+
+
 }

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -1,7 +1,10 @@
 package com.hedera.hashgraph.identity.hcs.did;
 
 import com.hedera.hashgraph.identity.DidError;
+import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import org.javatuples.Triplet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,118 @@ public class HcsDidTest {
         Assertions.assertNull(did.getClient());
         Assertions.assertNull(did.getTopicId());
         Assertions.assertNull(did.getNetwork());
+
+    }
+
+    @Test
+    @DisplayName("throws error if passed identifier is invalid")
+    void testIdentifier() {
+
+        for (String s : new String[]{
+                null,
+                "invalidDid1",
+                "did:invalid",
+                "did:invalidMethod:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.24352",
+                "did:hedera:invalidNetwork:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.24352",
+                "did:hedera:testnet:invalidAddress_0.0.24352_1.5.23462345",
+                "did:hedera:testnet_1.5.23462345",
+                "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknown:parameter=1_missing",
+                "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1=1",
+                "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:hedera:testnet:fid",
+                "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknownPart_0.0.1",
+                "did:notHedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1"}) {
+
+            Assertions.assertThrows(Exception.class, () -> new HcsDid(s, null, null));
+
+        }
+
+    }
+
+    @Test
+    @DisplayName("accepts client parameter")
+    void testAcceptClientParam() throws DidError {
+        var client = Client.forTestnet();
+        var identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
+        var did = new HcsDid(identifier, null, client);
+
+        Assertions.assertEquals(identifier, did.getIdentifier());
+        Assertions.assertNull(did.getPrivateKey());
+        Assertions.assertEquals(client, did.getClient());
+        Assertions.assertEquals("0.0.29613327", did.getTopicId().toString());
+        Assertions.assertEquals("testnet", did.getNetwork());
+
+    }
+
+
+    @Test
+    @DisplayName("throws error if topicId missing")
+    void throwsErrorWhenTopicIdMissing() {
+        Assertions.assertThrowsExactly(DidError.class, () -> HcsDid.parseIdentifier("did:hedera:testnet:z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk"), "DID string is invalid: topic ID is missing");
+
+    }
+
+    @Test
+    @DisplayName("throws error if invalid prefix")
+    void throwsErrorIfInvalidPrefix() {
+        Assertions.assertThrowsExactly(DidError.class, () -> HcsDid.parseIdentifier("abcd:hedera:testnet:z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk_0.0.1"), "DID string is invalid: invalid prefix.");
+
+    }
+
+    @Test
+    @DisplayName("throws error if invalid method name")
+    void throwsErrorIfInvalidMethodName() {
+        Assertions.assertThrowsExactly(DidError.class, () -> HcsDid.parseIdentifier("did:hashgraph:testnet:z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk_0.0.1"), "DID string is invalid: invalid method name: hashgraph");
+
+    }
+
+
+    @Test
+    @DisplayName("throws error if Invalid Hedera network")
+    void throwsErrorIfInvalidNetwork() {
+        Assertions.assertThrowsExactly(DidError.class, () -> HcsDid.parseIdentifier("did:hedera:nonetwork:z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk_0.0.1"), "DID string is invalid. Invalid Hedera network.");
+
+    }
+
+
+    @Test
+    @DisplayName("throws error if Invalid id string")
+    void throwsErrorIfInvalidString() {
+        Assertions.assertThrowsExactly(DidError.class, () -> HcsDid.parseIdentifier("did:hedera:testnet:z6Mkabcd_0.0.1"), "DID string is invalid. ID holds incorrect format.");
+
+    }
+
+    @Test
+    @DisplayName("should get array with NetworkName, topicId and didIdString")
+    void shouldParseArrayWithNetworkTopicIdAndIdString() throws DidError {
+
+        Triplet<String, TopicId, String> triplet = HcsDid.parseIdentifier(
+                "did:hedera:testnet:z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk_0.0.1"
+        );
+
+        Assertions.assertEquals("testnet", triplet.getValue0());
+        Assertions.assertEquals("0.0.1", triplet.getValue1().toString());
+        Assertions.assertEquals("z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk", triplet.getValue2());
+
+    }
+
+    @Test
+    @DisplayName("should get DID Id String from publicKey")
+    void ShouldGetDidIdStringFromPublicKey() {
+        var privateKey = PrivateKey.fromString(
+                "302e020100300506032b657004220420a4b76d7089dfd33c83f586990c3a36ae92fb719fdf262e7749d1b0ddd1d055b0"
+        );
+        var result = HcsDid.publicKeyToIdString(privateKey.getPublicKey());
+        Assertions.assertEquals("z6MkvD6JAfMyP6pgQoYxfE9rubgwLD9Hmz8rQh1FAxvbW8XB", result);
+    }
+
+    @Test
+    @DisplayName("should get publicKey from DID Id String")
+    void ShouldGetPublicKeyFromDidIdString() {
+        var privateKey = PrivateKey.fromString(
+                "302e020100300506032b657004220420a4b76d7089dfd33c83f586990c3a36ae92fb719fdf262e7749d1b0ddd1d055b0"
+        );
+        var result = HcsDid.stringToPublicKey("z6MkvD6JAfMyP6pgQoYxfE9rubgwLD9Hmz8rQh1FAxvbW8XB");
+        Assertions.assertEquals(privateKey.getPublicKey(), result);
 
     }
 

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -1,0 +1,37 @@
+package com.hedera.hashgraph.identity.hcs.did;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hedera.hashgraph.identity.DidError;
+import com.hedera.hashgraph.sdk.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HcsDidTest {
+    final AccountId operatorId = AccountId.fromString("0.0.2xxx");
+    final PrivateKey operatorKey = PrivateKey.fromString("302xxx");
+    final List<String> mirrorNetworks = List.of("hcs.testnet.mirrornode.hedera.com:5600");
+
+    final Client client = Client.forTestnet();
+
+    HcsDidTest() throws InterruptedException {
+        this.client.setMirrorNetwork(this.mirrorNetworks);
+        this.client.setOperator(this.operatorId, this.operatorKey);
+    }
+
+    @Test
+    @DisplayName("throws error if DID is already registered")
+    void itTestsIfDIDIsAlreadyRegistered() throws ReceiptStatusException, JsonProcessingException, PrecheckStatusException, TimeoutException, DidError {
+        PrivateKey privateKey = this.operatorKey;
+        HcsDid did = new HcsDid(null, privateKey, this.client);
+
+        did.register();
+        DidError error = assertThrows(DidError.class, did::register);
+        assertEquals("", error.getMessage());
+    }
+}

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hcs/did/HcsDidTest.java
@@ -1,27 +1,12 @@
 package com.hedera.hashgraph.identity.hcs.did;
 
 import com.hedera.hashgraph.identity.DidError;
-import com.hedera.hashgraph.sdk.AccountId;
-import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 public class HcsDidTest {
-    final AccountId operatorId = AccountId.fromString("0.0.12710106");
-    final PrivateKey operatorKey = PrivateKey.fromString("302e020100300506032b657004220420bc45334a1313725653d3513fcc67edb15f76985f537ca567e2177b0be9906d49");
-    final List<String> mirrorNetworks = List.of("hcs.testnet.mirrornode.hedera.com:5600");
-
-    final Client client = Client.forTestnet();
-
-    HcsDidTest() throws InterruptedException {
-        this.client.setMirrorNetwork(this.mirrorNetworks);
-        this.client.setOperator(this.operatorId, this.operatorKey);
-    }
-
 
     @Test
     @DisplayName("throws error because of missing identifier and privateKey")

--- a/lib/src/test/java/com/hedera/hashgraph/identity/utils/HashingTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/utils/HashingTest.java
@@ -21,6 +21,5 @@ public class HashingTest {
         assertTrue(base58btcEncodedString.startsWith("z6Mk"));
         assertArrayEquals(publickeybytes, decodedPublicKeyBytes);
     }
-
-
+    
 }


### PR DESCRIPTION
```
java.lang.AbstractMethodError: Receiver class io.grpc.okhttp.OkHttpClientTransport does not define or inherit an implementation of the resolved method 'abstract io.grpc.internal.ClientStream newStream(io.grpc.MethodDescriptor, io.grpc.Metadata, io.grpc.CallOptions, io.grpc.ClientStreamTracer[])' of interface io.grpc.internal.ClientTransport.
java.lang.RuntimeException: java.lang.AbstractMethodError: Receiver class io.grpc.okhttp.OkHttpClientTransport does not define or inherit an implementation of the resolved method 'abstract io.grpc.internal.ClientStream newStream(io.grpc.MethodDescriptor, io.grpc.Metadata, io.grpc.CallOptions, io.grpc.ClientStreamTracer[])' of interface io.grpc.internal.ClientTransport.
	at com.hedera.hashgraph.sdk.Executable.execute(Executable.java:264)
	at com.hedera.hashgraph.sdk.Transaction.execute(Transaction.java:32)
	at com.hedera.hashgraph.sdk.Executable.execute(Executable.java:215)
	at com.hedera.hashgraph.sdk.Transaction.execute(Transaction.java:32)
	at com.hedera.hashgraph.identity.hcs.did.HcsDid.register(HcsDid.java:166)
	at com.hedera.hashgraph.identity.hcs.did.HcsDidTest.itTestsIfDIDIsAlreadyRegistered(HcsDidTest.java:33)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
...
```